### PR TITLE
Build changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,188 +1,229 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>gov.nasa.jpl</groupId>
-    <artifactId>mms-share</artifactId>
-    <version>2.2.1</version>
-    <name>view-share AMP project</name>
-    <packaging>amp</packaging>
-    <description>Manages the lifecycle of the view-share AMP (Alfresco Module Package)</description>
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>gov.nasa.jpl</groupId>
+  <artifactId>mms-share</artifactId>
+  <version>2.2.1</version>
+  <name>view-share AMP project</name>
+  <packaging>amp</packaging>
+  <description>Manages the lifecycle of the view-share AMP (Alfresco Module Package)</description>
 
   <distributionManagement>
-      <!-- use mvn -U deploy -DgeneratePom=true -Dpackaging=jar  -->
-      <repository>
-          <id>artifactory</id>
-          <name>releases</name>
-          <url>http://europambee-build.jpl.nasa.gov:8082/artifactory/libs-release-local</url>
-      </repository>
-      <snapshotRepository>
-          <id>artifactory</id>
-          <name>snapshots-dist</name>
-          <url>http://europambee-build.jpl.nasa.gov:8082/artifactory/libs-snapshot-local</url>
-      </snapshotRepository>
+    <!-- use mvn -U deploy -DgeneratePom=true -Dpackaging=jar  -->
+    <repository>
+      <id>artifactory</id>
+      <name>releases</name>
+      <url>http://europambee-build.jpl.nasa.gov:8082/artifactory/libs-release-local</url>
+    </repository>
+    <snapshotRepository>
+      <id>artifactory</id>
+      <name>snapshots-dist</name>
+      <url>http://europambee-build.jpl.nasa.gov:8082/artifactory/libs-snapshot-local</url>
+    </snapshotRepository>
   </distributionManagement>
 
-    <parent>
-        <groupId>org.alfresco.maven</groupId>
-        <artifactId>alfresco-sdk-parent</artifactId>
-        <version>1.1.1</version>
-    </parent>
+  <parent>
+    <groupId>org.alfresco.maven</groupId>
+    <artifactId>alfresco-sdk-parent</artifactId>
+    <version>1.1.1</version>
+  </parent>
 
-    <profiles>
-        <profile>
-            <id>mbee-dev</id>
-            <properties>
-                <env.BUILD_NUMBER>1</env.BUILD_NUMBER>
-            </properties>
-        </profile>
-        <profile>
-            <id>jenkins</id>
-        </profile>
-    </profiles>
-    
-    <!-- 
+  <!-- 
        | SDK properties have sensible defaults in the SDK parent,
        | but you can override the properties below to use another version. 
        | For more available properties see the alfresco-sdk-parent POM. 
-       -->
-    <properties>
-        <!-- Defines the alfresco edition to compile against. Allowed values are [org.alfresco|org.alfresco.enterprise]--> 
-        <alfresco.groupId>org.alfresco</alfresco.groupId>
-        <!-- Defines the alfresco version to compile against -->
+  -->
+  <properties>
+    <!-- Defines the alfresco edition to compile against. Allowed values are [org.alfresco|org.alfresco.enterprise]--> 
+    <alfresco.groupId>org.alfresco</alfresco.groupId>
+    <!-- Defines the alfresco version to compile against -->
+    <alfresco.version>4.2.e</alfresco.version>
+    <app.log.root.level>WARN</app.log.root.level>
+    <alfresco.data.location>alf_data_dev</alfresco.data.location>
+    <!-- Defines the target WAR artifactId to run this amp, only used with the -Pamp-to-war switch
+         .    | Allowed values: alfresco | share. Defaults to a repository AMP, but could point to your foundation WAR -->
+    <alfresco.client.war>share</alfresco.client.war>
+    <!-- Defines the target WAR groupId to run this amp, only used with the -Pamp-to-war switch
+         .    | Could be org.alfresco | org.alfresco.enterprise or your corporate groupId -->
+    <alfresco.client.war.groupId>org.alfresco</alfresco.client.war.groupId>
+    <!-- Defines the target WAR version to run this amp, only used with the -Pamp-to-war switch -->
+    <alfresco.client.war.version>4.2.e</alfresco.client.war.version>
+    <!-- This controls which properties will be picked in src/test/properties for embedded run -->
+    <env>local</env>
+    <!-- specify the testing deployment info -->       
+    <maven.host>localhost</maven.host>
+    <maven.tomcat.port>8082</maven.tomcat.port>
+    <!-- The following is used in share-config-custom.xml in case the port number of
+    EMS-Repo needs to be changed during testing -->
+    <ems_alfresco_port>8080</ems_alfresco_port>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
+
+  <profiles>
+    <!-- Alfresco Community Edition -->
+    <profile>
+      <id>community</id>
+      <properties>
         <alfresco.version>4.2.e</alfresco.version>
-        <app.log.root.level>WARN</app.log.root.level>
-        <alfresco.data.location>alf_data_dev</alfresco.data.location>
-        <!-- Defines the target WAR artifactId to run this amp, only used with the -Pamp-to-war switch
-        .    | Allowed values: alfresco | share. Defaults to a repository AMP, but could point to your foundation WAR -->
-        <alfresco.client.war>share</alfresco.client.war>
-        <!-- Defines the target WAR groupId to run this amp, only used with the -Pamp-to-war switch
-        .    | Could be org.alfresco | org.alfresco.enterprise or your corporate groupId -->
-        <alfresco.client.war.groupId>org.alfresco</alfresco.client.war.groupId>
-        <!-- Defines the target WAR version to run this amp, only used with the -Pamp-to-war switch -->
         <alfresco.client.war.version>4.2.e</alfresco.client.war.version>
-        <!-- This controls which properties will be picked in src/test/properties for embedded run -->
-        <env>local</env>
-        <!-- specify the testing deployment info -->       
-  		<maven.host>localhost</maven.host>
-  		<maven.tomcat.port>8081</maven.tomcat.port>
-  		
-		<maven.test.skip>true</maven.test.skip>
-    </properties>
-
-    <!-- Here we realize the connection with the Alfresco selected platform 
-        (e.g.version and edition) -->
-    <dependencyManagement>
-        <dependencies>
-            <!-- This will import the dependencyManagement for all artifacts in the selected Alfresco version/edition
-                (see http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies) 
-                NOTE: You still need to define dependencies in your POM, but you can omit version as it's enforced by this dependencyManagement. NOTE: It defaults 
-                to the latest version this SDK pom has been tested with, but alfresco version can/should be overridden in your project's pom -->
-            <dependency>
-                <groupId>${alfresco.groupId}</groupId>
-                <artifactId>alfresco-platform-distribution</artifactId>
-                <version>${alfresco.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-    <!-- Following dependencies are needed for compiling Java code in src/main/java; 
-         <scope>provided</scope> is inherited for each of the following; 
-         for more info, please refer to alfresco-platform-distribution POM -->
+        <alfrescoEditionName>community</alfrescoEditionName>
+        <packageName>mms-share-community</packageName>
+      </properties>
+    </profile>
+    <!-- Alfresco Enterprise Edition -->
+    <profile>
+      <id>enterprise</id>
+      <properties>
+        <alfresco.version>4.2.4</alfresco.version>
+        <alfresco.client.war.version>4.2.4</alfresco.client.war.version>
+        <alfrescoEditionName>enterprise</alfrescoEditionName>
+        <packageName>mms-share-enterprise</packageName>
+      </properties>
+      <repositories>
+        <repository>
+          <id>alfresco-private-repository</id>
+          <url>https://artifacts.alfresco.com/nexus/content/groups/private</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <id>mbee-dev</id>
+      <properties>
+        <env.BUILD_NUMBER>1</env.BUILD_NUMBER>
+      </properties>
+    </profile>
+    <profile>
+      <id>jenkins</id>
+    </profile>
+  </profiles>
+  
+  <!-- Here we realize the connection with the Alfresco selected platform 
+       (e.g.version and edition) -->
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>${alfresco.groupId}</groupId>
-            <artifactId>alfresco-repository</artifactId>
-        </dependency>
-        <!-- Test dependencies -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <!-- This will import the dependencyManagement for all artifacts in the selected Alfresco version/edition
+           (see http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies) 
+           NOTE: You still need to define dependencies in your POM, but you can omit version as it's enforced by this dependencyManagement. NOTE: It defaults 
+           to the latest version this SDK pom has been tested with, but alfresco version can/should be overridden in your project's pom -->
+      <dependency>
+        <groupId>${alfresco.groupId}</groupId>
+        <artifactId>alfresco-platform-distribution</artifactId>
+        <version>${alfresco.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
+  <!-- Following dependencies are needed for compiling Java code in src/main/java; 
+       <scope>provided</scope> is inherited for each of the following; 
+       for more info, please refer to alfresco-platform-distribution POM -->
+  <dependencies>
+    <dependency>
+      <groupId>${alfresco.groupId}</groupId>
+      <artifactId>alfresco-repository</artifactId>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <!-- This repository is only needed to retrieve Alfresco parent POM. 
-        NOTE: This can be removed when/if Alfresco will be on Maven Central 
-        
-        NOTE: The repository to be used for Alfresco Enterprise artifacts is
-        https://artifacts.alfresco.com/nexus/content/groups/private/. Please check
-        with Alfresco Support to get credentials to add to your ~/.m2/settings.xml
-        if you are a Enterprise customer or Partner  
-        -->
-    <repositories>
-        <repository>
-            <id>alfresco-public</id>
-            <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
-        </repository>
-        <repository>
-            <id>alfresco-public-snapshots</id>
-            <url>https://artifacts.alfresco.com/nexus/content/groups/public-snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
-    
-    <build>
-    		<pluginManagement>
-			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.alfresco.maven.plugin
-										</groupId>
-										<artifactId>
-											alfresco-maven-plugin
-										</artifactId>
-										<versionRange>
-											[1.0.2,)
-										</versionRange>
-										<goals>
-											<goal>set-version</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.codehaus.mojo
-										</groupId>
-										<artifactId>
-											build-helper-maven-plugin
-										</artifactId>
-										<versionRange>
-											[1.7,)
-										</versionRange>
-										<goals>
-											<goal>
-												add-test-resource
-											</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>    
+  <!-- This repository is only needed to retrieve Alfresco parent POM. 
+       NOTE: This can be removed when/if Alfresco will be on Maven Central 
+       
+       NOTE: The repository to be used for Alfresco Enterprise artifacts is
+       https://artifacts.alfresco.com/nexus/content/groups/private/. Please check
+       with Alfresco Support to get credentials to add to your ~/.m2/settings.xml
+       if you are a Enterprise customer or Partner  
+  -->
+  <repositories>
+    <repository>
+      <id>alfresco-public</id>
+      <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
+    </repository>
+    <repository>
+      <id>alfresco-public-snapshots</id>
+      <url>https://artifacts.alfresco.com/nexus/content/groups/public-snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
+  
+  <build>
+    <plugins>
+      <!-- which version of java are we compiling for -->
+      <plugin>
+      	<groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <verbose>false</verbose>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+	<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+	<plugin>
+	  <groupId>org.eclipse.m2e</groupId>
+	  <artifactId>lifecycle-mapping</artifactId>
+	  <version>1.0.0</version>
+	  <configuration>
+	    <lifecycleMappingMetadata>
+	      <pluginExecutions>
+		<pluginExecution>
+		  <pluginExecutionFilter>
+		    <groupId>
+		      org.alfresco.maven.plugin
+		    </groupId>
+		    <artifactId>
+		      alfresco-maven-plugin
+		    </artifactId>
+		    <versionRange>
+		      [1.0.2,)
+		    </versionRange>
+		    <goals>
+		      <goal>set-version</goal>
+		    </goals>
+		  </pluginExecutionFilter>
+		  <action>
+		    <ignore></ignore>
+		  </action>
+		</pluginExecution>
+		<pluginExecution>
+		  <pluginExecutionFilter>
+		    <groupId>
+		      org.codehaus.mojo
+		    </groupId>
+		    <artifactId>
+		      build-helper-maven-plugin
+		    </artifactId>
+		    <versionRange>
+		      [1.7,)
+		    </versionRange>
+		    <goals>
+		      <goal>
+			add-test-resource
+		      </goal>
+		    </goals>
+		  </pluginExecutionFilter>
+		  <action>
+		    <ignore></ignore>
+		  </action>
+		</pluginExecution>
+	      </pluginExecutions>
+	    </lifecycleMappingMetadata>
+	  </configuration>
+	</plugin>
+      </plugins>
+    </pluginManagement>
+  </build>    
 </project>

--- a/src/main/amp/config/alfresco/web-extension/share-config-custom.xml
+++ b/src/main/amp/config/alfresco/web-extension/share-config-custom.xml
@@ -53,4 +53,35 @@
       <filter/>
    </config>
    
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <endpoint>
+            <id>alfresco-noauth</id>
+            <name>Alfresco - unauthenticated access</name>
+            <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:${ems_alfresco_port}/alfresco/s</endpoint-url>
+            <identity>none</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:${ems_alfresco_port}/alfresco/s</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco-feed</id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+            <connector-id>http</connector-id>
+            <endpoint-url>http://localhost:${ems_alfresco_port}/alfresco/s</endpoint-url>
+            <basic-auth>true</basic-auth>
+            <identity>user</identity>
+         </endpoint>
+      </remote>
+   </config>
 </alfresco-config>

--- a/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/components/dashlets/docweb.get.js
+++ b/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/components/dashlets/docweb.get.js
@@ -20,8 +20,12 @@ function main()
    }
    
    var hostname = json.alfresco.host;
-   if(hostname.toLowerCase()=='localhost') hostname += ':' + json.alfresco.port;
-   hostname = json.alfresco.protocol + '://' + hostname;
+   var proto = json.alfresco.protocol;
+   var port = json.alfresco.port;
+   if((proto == "http" && port != 80)
+      || (proto == "https" && port != 443)) 
+       hostname += ':' + port;
+   hostname = proto + '://' + hostname;
    
    var siteName = page.url.templateArgs.site;
    if (siteName)

--- a/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
+++ b/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
@@ -1981,10 +1981,14 @@ function getAlfrescoHostname(){
 function getAlfrescoUrl(){
 	var json;
 	try{
-		json = getHostInfo();
-		var hostname = json.alfresco.host;
-		if(hostname.toLowerCase()=='localhost') hostname += ':' + json.alfresco.port;
-		return (json.alfresco.protocol + '://' + hostname);
+	    json = getHostInfo();
+	    var hostname = json.alfresco.host;
+	    var proto = json.alfresco.protocol;
+	    var port = json.alfresco.port;
+	    if((proto == "http" && port != 80)
+	       || (proto == "https" && port != 443)) 
+		hostname += ':' + port;
+	    return (proto + '://' + hostname);
 	}
 	catch(err){
 		throw new Error('Unable to get host info.');


### PR DESCRIPTION
Added ems_alfresco_port property to allow alfresco port to be changed
for testing, and share can connect
Added community and enterprise profiles to pom.xml
Specified source and target versions in compiler plugin
Added section to share-config-custom.xml for alfresco port, will be
rewritten by property in pom.xml
Fixed hostname logic in docweb.get.js and share-header.lib.js so that
port is added to hostname unless it is a standard port number (80 or 443)
