### PR TITLE
Changed url construction to use port number if non-standard port

### DIFF
--- a/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/components/dashlets/docweb.get.js
+++ b/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/components/dashlets/docweb.get.js
@@ -20,8 +20,12 @@ function main()
    }
    
    var hostname = json.alfresco.host;
-   if(hostname.toLowerCase()=='localhost') hostname += ':' + json.alfresco.port;
-   hostname = json.alfresco.protocol + '://' + hostname;
+   var proto = json.alfresco.protocol;
+   var port = json.alfresco.port;
+   if((proto == "http" && port != 80)
+      || (proto == "https" && port != 443))
+           hostname += ':' + port;
+   hostname = proto + '://' + hostname;
    
    var siteName = page.url.templateArgs.site;
    if (siteName)

--- a/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
+++ b/src/main/amp/web/WEB-INF/classes/alfresco/site-webscripts/org/alfresco/share/imports/share-header.lib.js
@@ -1958,8 +1958,12 @@ function getAlfrescoUrl(){
 	try{
 		json = getHostInfo();
 		var hostname = json.alfresco.host;
-		if(hostname.toLowerCase()=='localhost') hostname += ':' + json.alfresco.port;
-		return (json.alfresco.protocol + '://' + hostname);
+		var proto = json.alfresco.protocol;
+		var port = json.alfresco.port;
+		if((proto == "http" && port != 80)
+		   || (proto = "https" && port != 443)) 
+			hostname += ':' + port;
+		return (proto + '://' + hostname);
 	}
 	catch(err){
 		throw new Error('Unable to get host info.');


### PR DESCRIPTION
EMS link in share has the wrong url if EMS-Repo is using a port that is not 80 or 443.
